### PR TITLE
bump pacman version

### DIFF
--- a/cachyos-repo.sh
+++ b/cachyos-repo.sh
@@ -162,7 +162,7 @@ run_install() {
               "${mirror_url}/cachyos-mirrorlist-18-1-any.pkg.tar.zst"    \
               "${mirror_url}/cachyos-v3-mirrorlist-18-1-any.pkg.tar.zst" \
               "${mirror_url}/cachyos-v4-mirrorlist-6-1-any.pkg.tar.zst"  \
-              "${mirror_url}/pacman-6.1.0-7-x86_64.pkg.tar.zst"
+              "${mirror_url}/pacman-7.0.0.r3.gf3211df-2-x86_64.pkg.tar.zst"
 
     local is_repo_added="$(check_if_repo_was_added)"
     local is_repo_commented="$(check_if_repo_was_commented)"


### PR DESCRIPTION
Was getting the error below when trying to run this on my Arch Linux installation.

```
> sudo ./cachyos-repo.sh
==> Installing CachyOS repo..
gpg: key F3B607488DB35A47: "CachyOS <admin@cachyos.org>" not changed gpg: Total number processed: 1
gpg:              unchanged: 1
  -> Locally signed 1 key.
==> Updating trust database...
gpg: next trustdb check due at 2024-11-09
:: Retrieving packages...
 pacman-6.1.0-7-x86_64.pkg.tar.zst failed to download
error: failed retrieving file 'pacman-6.1.0-7-x86_64.pkg.tar.zst' from mirror.cachyos.org : The requested URL returned error: 404
warning: failed to retrieve some files
```

Is there a more sustainable way to fixing this than relying on this version being updated every now and then?